### PR TITLE
Add support for LTS and Current framework versions

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -12,5 +12,22 @@
     "tags": {
         "language": "C#"
     },
-    "sourceName": "NancyTemplate"
+    "sourceName": "NancyTemplate",
+    "symbols": {
+        "Framework": {
+            "type": "parameter",
+            "datatype": "choice",
+            "choices": [
+                {
+                "choice": "netcoreapp1.0",
+                "description": "Target netcoreapp1.0"
+                },
+                {
+                "choice": "netcoreapp1.1",
+                "description": "Target netcoreapp1.1"
+                }
+            ],
+            "defaultValue": "netcoreapp1.1"
+        }
+    }
 }

--- a/NancyTemplate.csproj
+++ b/NancyTemplate.csproj
@@ -1,13 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1'">netcoreapp1.0</TargetFramework>
+    <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1'">netcoreapp1.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>NancyTemplate</AssemblyName>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+  <ItemGroup Condition="'$(Framework)' != 'netcoreapp1.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="1.0.1" />
+    <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Framework)'=='netcoreapp1.1'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="1.1.0" />


### PR DESCRIPTION
This commit adds conditional support for different target
frameworks in template.
The default target framework is setup to 1.1 - as per recent
changes to dotnet/templating:

https://github.com/dotnet/templating/pull/347/files

I cannot check this PR fully on OS X, so below are my remarks and I think PR could be helpful even if not merged.

- I've changed condition variable name to *framework* as defined in `template.json` - followign dotnet/templating 
- the packages version is taken from sample I've verified to run correctly for LTS/Current when updating generator/aspnet: OmniSharp/generator-aspnet#930

Thanks!